### PR TITLE
Implement HEAD /secure health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ Servidor Node.js para envio de mensagens via WhatsApp usando Baileys.
 - `POST /upload-numbers` - envia arquivo `.xlsx` ou `.csv` com coluna `numero` ou `number` contendo os números.
 - `GET /numbers` - lista os números armazenados.
 - `POST /disparo` - envia mensagem para todos os números (`{ "mensagem": "texto", "intervalo": 1000 }`).
+- `HEAD /secure` - checagem rápida que retorna `200` caso o servidor esteja ativo.
 
 Para utilizar, instale as dependências com `npm install` e inicie o servidor com `npm start`.

--- a/index.js
+++ b/index.js
@@ -133,6 +133,11 @@ app.get('/send', async (req, res) => {
   }
 });
 
+// Endpoint para verificações via método HEAD
+app.head('/secure', (_, res) => {
+  res.status(200).end();
+});
+
 async function startBot() {
   const { state, saveCreds } = await useMultiFileAuthState('auth_info_baileys');
   sock = makeWASocket({ auth: state, printQRInTerminal: false });


### PR DESCRIPTION
## Summary
- add a new `/secure` endpoint using the HEAD method
- document the new endpoint in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f74a2c36c8326bc7e3ce7b29c8580