### PR TITLE
Implement /info endpoint to display project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Servidor Node.js para envio de mensagens via WhatsApp usando Baileys.
 - `POST /add-number` - adiciona um número individual (`{ "numero": "5511999999999" }`).
 - `POST /upload-numbers` - envia arquivo `.xlsx` ou `.csv` com coluna `numero` ou `number` contendo os números.
 - `GET /numbers` - lista os números armazenados.
+- `GET /info` - exibe todos os arquivos do projeto e seus conteúdos.
 - `POST /disparo` - envia mensagem para todos os números (`{ "mensagem": "texto", "intervalo": 1000 }`).
 - `GET /grupos` - lista os grupos dos quais o bot participa.
 - `GET /grupos/:nome` - mostra todos os números do grupo indicado e informa se cada um é administrador.


### PR DESCRIPTION
## Summary
- expose project file contents via new `/info` route
- document `/info` in the README

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6855b42fcc7c8326847b9cc0f481540d