### PR TITLE
Add daily connection status alerts

### DIFF
--- a/Memoria.txt
+++ b/Memoria.txt
@@ -1,0 +1,2 @@
+User requested periodic status messages every 24h and notifications on WhatsApp connection changes.
+Implemented sendStatus function and event hooks.


### PR DESCRIPTION
## Summary
- send periodic status updates to 556186660241
- notify on disconnect and reconnection events
- save memory file

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ad8d370b4832683347ca6cebe7f8a